### PR TITLE
pc - add tests for github id on show page of roster student

### DIFF
--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -25,11 +25,16 @@
   <%= @roster_student.enrolled ? "True" : "False" %>
 </p>
 
+<% if @roster_student.username.nil? %>
+<p>
+  <strong>Github ID:</strong><span class="js-no-github-id"> Unknown</span>
+</p>
+<% else %>
 <p>
   <strong>Github ID:</strong>
-  <a href="https://github.com/<%= @roster_student.username %>"><%= @roster_student.username %> </a>
+  <a class="js-github-id" href="https://github.com/<%= @roster_student.username %>"><%= @roster_student.username %></a>
 </p>
-
+<% end %>
 
 <%= link_to 'Edit', edit_course_roster_student_path(@parent, @roster_student), :class => "btn btn-outline-secondary" %> |  
 <%= link_to 'Back', course_path(@parent), :class => "btn btn-outline-secondary" %>

--- a/test/controllers/roster_students_controller_test.rb
+++ b/test/controllers/roster_students_controller_test.rb
@@ -11,6 +11,33 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
     @user = users(:wes)
     @user.add_role(:admin)
     sign_in @user
+
+    @user2 = User.create!(
+      name: 'Chris',
+      username: 'cgaucho',
+      uid: 1234567,
+      provider: 'GitHub',
+      email: 'cgaucho@example.edu',
+      password: 'a9sd8ua98fu9as'
+    )
+    @roster_student_with_github = RosterStudent.create!(
+      perm: 1234,
+      first_name: 'Chris',
+      last_name: 'Gaucho',
+      email: 'cgaucho@example.edu',
+      course: @course2,
+      enrolled: false,
+      user: @user2
+    )
+    @roster_student_with_no_github = RosterStudent.create!(
+      perm: 5678,
+      first_name: 'Lyn',
+      last_name: 'DelPlaya',
+      email: 'ldelplaya@example.edu',
+      course: @course2,
+      enrolled: false,
+      user: nil
+    )
   end
 
   test "should get new" do
@@ -71,6 +98,18 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
   test "should show roster_student" do
     get course_roster_student_path(:course_id=> @roster_student.course_id, :id=> @roster_student.id)
     assert_response :success
+  end
+
+  test "should show github id if roster_student has one" do
+    get course_roster_student_path(:course_id=> @roster_student_with_github.course_id, :id=> @roster_student_with_github.id)
+    assert_response :success
+    assert_select 'a.js-github-id[href=?]','https://github.com/cgaucho'
+  end
+
+  test "should not show github id if roster_student has none" do
+    get course_roster_student_path(:course_id=> @roster_student_with_no_github.course_id, :id=> @roster_student_with_no_github.id)
+    assert_response :success
+    assert_select 'span.js-no-github-id'
   end
 
   test "should get edit" do


### PR DESCRIPTION
In this PR, I add tests to @ProbablyFaiz 's code to add github id to the show page for roster students.